### PR TITLE
Change on room and databinding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
+    id 'kotlin-parcelize'
     id 'com.google.gms.google-services'  // Google Services plugin
 }
 

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/AddActivity.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/AddActivity.kt
@@ -20,6 +20,7 @@ import com.fallTurtle.myrestaurantgallery.R
 import com.fallTurtle.myrestaurantgallery.databinding.ActivityAddBinding
 import com.fallTurtle.myrestaurantgallery.dialog.ImgDialog
 import com.fallTurtle.myrestaurantgallery.dialog.ProgressDialog
+import com.fallTurtle.myrestaurantgallery.etc.Configurations
 import com.fallTurtle.myrestaurantgallery.etc.NetworkWatcher
 import com.fallTurtle.myrestaurantgallery.model.retrofit.value_object.LocationPair
 import com.fallTurtle.myrestaurantgallery.model.room.RestaurantInfo
@@ -102,7 +103,7 @@ class  AddActivity : AppCompatActivity(){
         binding.spinnerEntries = resources.getStringArray(R.array.category_spinner)
 
         //인텐트로 선택된 데이터 db 아이디 가져와서 뷰모델에 적용 (실패 시 화면 종료)
-        itemId = intent.getStringExtra("item_id")
+        itemId = intent.getStringExtra(Configurations.ITEM_ID)
         itemId?.let { itemViewModel.setProperItem(it) }
 
         //각 뷰의 리스너들 설정

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/AddActivity.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/AddActivity.kt
@@ -272,7 +272,7 @@ class  AddActivity : AppCompatActivity(){
             memo = binding.etMemo.text.toString(), rate = binding.rbRatingBar.rating.toInt(),
             latitude = itemLocation.latitude, longitude = itemLocation.longitude, dbID = newID)
 
-        itemViewModel.insertItem(newItem)
+        itemViewModel.insertItem(newItem, imgUri)
     }
 
 

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/LoginActivity.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/LoginActivity.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.fallTurtle.myrestaurantgallery.R
 import com.fallTurtle.myrestaurantgallery.databinding.ActivityLoginBinding
 import com.fallTurtle.myrestaurantgallery.dialog.ProgressDialog
+import com.fallTurtle.myrestaurantgallery.etc.Configurations
 import com.fallTurtle.myrestaurantgallery.view_model.UserViewModel
 import com.fallTurtle.myrestaurantgallery.view_model.ItemViewModel
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -42,7 +43,7 @@ class LoginActivity: AppCompatActivity() {
     private var itemProgress = false
 
     //공유 설정 (로그인 유지 여부)
-    private val sharedPreferences by lazy{ getSharedPreferences("loginCheck", MODE_PRIVATE) }
+    private val sharedPreferences by lazy{ getSharedPreferences(Configurations.LOGIN_CHECK_PREFERENCE, MODE_PRIVATE) }
 
 
     //--------------------------------------------

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/MainActivity.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/MainActivity.kt
@@ -15,6 +15,7 @@ import com.fallTurtle.myrestaurantgallery.R
 import com.fallTurtle.myrestaurantgallery.adapter.ItemAdapter
 import com.fallTurtle.myrestaurantgallery.databinding.ActivityMainBinding
 import com.fallTurtle.myrestaurantgallery.dialog.ProgressDialog
+import com.fallTurtle.myrestaurantgallery.etc.Configurations
 import com.fallTurtle.myrestaurantgallery.model.room.RestaurantInfo
 import com.fallTurtle.myrestaurantgallery.view_model.UserViewModel
 import com.fallTurtle.myrestaurantgallery.view_model.ItemViewModel
@@ -50,7 +51,7 @@ class MainActivity : AppCompatActivity() {
     private val progressDialog by lazy { ProgressDialog(this) }
 
     //공유 설정 (로그인 유지 여부)
-    private val sharedPreferences by lazy{ getSharedPreferences("loginCheck", MODE_PRIVATE) }
+    private val sharedPreferences by lazy{ getSharedPreferences(Configurations.LOGIN_CHECK_PREFERENCE, MODE_PRIVATE) }
 
     // 유저와 아이템 부분의 비즈니스 작업의 상태 등을 판별할 프로퍼티
     private var userProgress = false

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/RecordActivity.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/activity/RecordActivity.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.fallTurtle.myrestaurantgallery.R
 import com.fallTurtle.myrestaurantgallery.databinding.ActivityRecordBinding
 import com.fallTurtle.myrestaurantgallery.dialog.ProgressDialog
+import com.fallTurtle.myrestaurantgallery.etc.Configurations
 import com.fallTurtle.myrestaurantgallery.model.room.RestaurantInfo
 import com.fallTurtle.myrestaurantgallery.view_model.ItemViewModel
 
@@ -54,7 +55,7 @@ class RecordActivity : AppCompatActivity() {
         supportActionBar?.setDisplayShowTitleEnabled(false)
 
         //인텐트로 선택된 데이터 db 아이디 가져와서 뷰모델에 적용 (실패 시 화면 종료)
-        itemId = intent.getStringExtra("item_id")
+        itemId = intent.getStringExtra(Configurations.ITEM_ID)
 
         //옵저버 설정
         setObservers()
@@ -119,7 +120,7 @@ class RecordActivity : AppCompatActivity() {
     /* 수정 버튼 클릭시 id 정보를 가지고 AddActivity 화면으로 이동하는 함수  */
     private fun moveToEditActivity(){
         Intent(this, AddActivity::class.java).also{
-            it.putExtra("item_id", itemId); startActivity(it)
+            it.putExtra(Configurations.ITEM_ID, itemId); startActivity(it)
         }
     }
 

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/adapter/ItemAdapter.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/adapter/ItemAdapter.kt
@@ -72,10 +72,9 @@ class ItemAdapter(windowWidth: Int) : RecyclerView.Adapter<ItemAdapter.CustomVie
 
             //클릭 리스너 설정 (id에 따른 정보를 가지고 record 화면으로 넘어감)
             itemView.setOnClickListener { v ->
-                binding.info?.dbID.let { id ->
-                    val record = Intent(v.context, RecordActivity::class.java)
-                    record.putExtra(Configurations.ITEM_ID, id)
-                    v.context.startActivity(record)
+                Intent(v.context, RecordActivity::class.java).let {
+                    it.putExtra(Configurations.ITEM_ID, binding.info?.dbID)
+                    v.context.startActivity(it)
                 }
             }
         }

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/adapter/ItemAdapter.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/adapter/ItemAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.fallTurtle.myrestaurantgallery.activity.RecordActivity
 import com.fallTurtle.myrestaurantgallery.databinding.EachItemBinding
+import com.fallTurtle.myrestaurantgallery.etc.Configurations
 import com.fallTurtle.myrestaurantgallery.model.room.RestaurantInfo
 
 /**
@@ -14,7 +15,7 @@ import com.fallTurtle.myrestaurantgallery.model.room.RestaurantInfo
  **/
 class ItemAdapter(windowWidth: Int) : RecyclerView.Adapter<ItemAdapter.CustomViewHolder>() {
     //각 아이템뷰의 길이 (가로, 세로)
-    private val holderWidth = windowWidth / 7 * 3
+    private val holderWidth = windowWidth/7 * 3
     private val holderHeight = holderWidth/6 * 5
 
     //리사이클러뷰를 이루는 리스트 데이터를 저장하는 컬렉션
@@ -73,7 +74,7 @@ class ItemAdapter(windowWidth: Int) : RecyclerView.Adapter<ItemAdapter.CustomVie
             itemView.setOnClickListener { v ->
                 binding.info?.dbID.let { id ->
                     val record = Intent(v.context, RecordActivity::class.java)
-                    record.putExtra("item_id", id)
+                    record.putExtra(Configurations.ITEM_ID, id)
                     v.context.startActivity(record)
                 }
             }

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/etc/Configurations.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/etc/Configurations.kt
@@ -1,0 +1,7 @@
+package com.fallTurtle.myrestaurantgallery.etc
+
+object Configurations {
+    const val ITEM_ID = "item_id"
+
+    const val LOGIN_CHECK_PREFERENCE = "loginCheck"
+}

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/model/room/InfoRoomDao.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/model/room/InfoRoomDao.kt
@@ -4,7 +4,7 @@ import androidx.room.*
 
 @Dao
 interface InfoRoomDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert
     suspend fun insert(item: RestaurantInfo)
 
     @Update

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/model/room/InfoRoomDao.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/model/room/InfoRoomDao.kt
@@ -7,6 +7,9 @@ interface InfoRoomDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(item: RestaurantInfo)
 
+    @Update
+    suspend fun update(item: RestaurantInfo)
+
     @Delete
     suspend fun delete(item: RestaurantInfo)
 
@@ -17,5 +20,5 @@ interface InfoRoomDao {
     suspend fun clearAllItems()
 
     @Query("SELECT * FROM RestaurantInfo WHERE dbID is :id")
-    suspend fun getProperItem(id: String): RestaurantInfo
+    suspend fun getProperItem(id: String): RestaurantInfo?
 }

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/model/room/RestaurantInfo.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/model/room/RestaurantInfo.kt
@@ -2,20 +2,18 @@ package com.fallTurtle.myrestaurantgallery.model.room
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import java.text.SimpleDateFormat
-import java.util.*
 
 @Entity
 data class RestaurantInfo(
         @PrimaryKey val dbID:String = "",
-        var imageName:String? = null,
-        var imagePath:String? = null,
-        var name:String = "",
-        var location:String = "",
-        var categoryNum:Int = 0,
-        var category:String = "",
-        var rate:Int = 0,
-        var memo:String = "",
-        var date:String = SimpleDateFormat ( "yyyy년 M월 d일", Locale.KOREA).format(Date(Calendar.getInstance().timeInMillis)),
-        var latitude:Double = -1.0,
-        var longitude:Double = -1.0)
+        var imageName:String?,
+        var imagePath:String?,
+        var name:String,
+        var location:String,
+        var categoryNum:Int,
+        var category:String,
+        var rate:Int,
+        var memo:String,
+        var date:String,
+        var latitude:Double,
+        var longitude:Double)

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/repository/item/ItemRepository.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/repository/item/ItemRepository.kt
@@ -27,7 +27,9 @@ class ItemRepository(application: Application) {
     // 비즈니스 로직 함수 영역
 
     /* 아이템 삽입 이벤트를 정의한 함수 */
-    suspend fun itemInsert(item: RestaurantInfo) {
+    suspend fun itemInsert(item: RestaurantInfo, uri: Uri?) {
+        item.imageName?.let { name -> uri?.let{ item.imagePath = remoteImageRepository.insertImage(name, it) } }
+
         remoteDataRepository.insertData(item)
         localDataRepository.insertData(item)
     }

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/repository/item/data/DataRepository.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/repository/item/data/DataRepository.kt
@@ -10,13 +10,16 @@ interface DataRepository {
     suspend fun getAllData(): List<RestaurantInfo>
 
     /* 특정 데이터를 가져오는 함수 */
-    suspend fun getProperData(id:String): RestaurantInfo
+    suspend fun getProperData(id:String): RestaurantInfo?
 
     /* 데이터를 모두 지우는 함수 */
     suspend fun clearData()
 
     /* 특정 데이터를 추가하는 함수 */
     suspend fun insertData(data: RestaurantInfo)
+
+    /* 특정 데이터를 갱신하는 함수 */
+    suspend fun updateData(data: RestaurantInfo)
 
     /* 특정 데이터를 제거하는 함수 */
     suspend fun deleteData(data: RestaurantInfo)

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/repository/item/data/FireStoreRepository.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/repository/item/data/FireStoreRepository.kt
@@ -28,11 +28,11 @@ class FireStoreRepository: DataRepository {
     }
 
     /* 특정 데이터를 가져오는 함수 */
-    override suspend fun getProperData(id: String): RestaurantInfo {
+    override suspend fun getProperData(id: String): RestaurantInfo? {
         return suspendCoroutine { continuation ->
             collectionRef().document(id).get().addOnCompleteListener {
-                if(it.isSuccessful) continuation.resume(it.result.toObject(RestaurantInfo::class.java) ?: RestaurantInfo())
-                else continuation.resume(RestaurantInfo())
+                if(it.isSuccessful) continuation.resume(it.result.toObject(RestaurantInfo::class.java))
+                else continuation.resume(null)
             }
         }
     }
@@ -46,6 +46,26 @@ class FireStoreRepository: DataRepository {
     override suspend fun insertData(data: RestaurantInfo) {
         suspendCoroutine<Any?> { continuation ->
             collectionRef().document(data.dbID).set(data).addOnCompleteListener { continuation.resume(null) }
+        }
+    }
+
+    /* 특정 데이터를 갱신하는 함수 */
+    override suspend fun updateData(data: RestaurantInfo) {
+        suspendCoroutine<Any?> { continuation ->
+            with(collectionRef().document(data.dbID)){
+                update("category", data.category)
+                update("categoryNum", data.categoryNum)
+                update("date", data.date)
+                update("imageName", data.imageName)
+                update("imagePath", data.imagePath)
+                update("latitude", data.latitude)
+                update("longitude", data.longitude)
+                update("memo", data.memo)
+                update("name", data.name)
+                update("rate", data.rate)
+            }.addOnCompleteListener {
+                continuation.resume(null)
+            }
         }
     }
 

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/repository/item/data/RoomRepository.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/repository/item/data/RoomRepository.kt
@@ -22,7 +22,7 @@ class RoomRepository(application: Application): DataRepository {
     }
 
     /* 특정 데이터를 가져오는 함수 */
-    override suspend fun getProperData(id: String): RestaurantInfo {
+    override suspend fun getProperData(id: String): RestaurantInfo? {
         return roomDao.getProperItem(id)
     }
 
@@ -34,6 +34,11 @@ class RoomRepository(application: Application): DataRepository {
     /* 특정 데이터를 추가하는 함수 */
     override suspend fun insertData(data: RestaurantInfo) {
         roomDao.insert(data)
+    }
+
+    /* 특정 데이터를 갱신하는 함수 */
+    override suspend fun updateData(data: RestaurantInfo) {
+        roomDao.update(data)
     }
 
     /* 특정 데이터를 제거하는 함수 */

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/view_model/ItemViewModel.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/view_model/ItemViewModel.kt
@@ -86,10 +86,10 @@ class ItemViewModel(application: Application): AndroidViewModel(application) {
     }
 
     /* 기본적인 아이템 삽입 이벤트를 위한 함수 */
-    fun insertItem(item: RestaurantInfo) {
+    fun insertItem(item: RestaurantInfo, imgUri: Uri?) {
         viewModelScope.launch(Dispatchers.IO) {
             insideProgressing.postValue(true)
-            itemRepository.itemInsert(item)
+            itemRepository.itemInsert(item, imgUri)
             insideProgressing.postValue(false)
             insideWorkFinishFlag.postValue(true)
         }

--- a/app/src/main/java/com/fallTurtle/myrestaurantgallery/view_model/ItemViewModel.kt
+++ b/app/src/main/java/com/fallTurtle/myrestaurantgallery/view_model/ItemViewModel.kt
@@ -85,11 +85,21 @@ class ItemViewModel(application: Application): AndroidViewModel(application) {
         }
     }
 
-    /* 기본적인 아이템 삽입(혹은 갱신) 이벤트를 위한 함수 */
-    fun insertItem(item: RestaurantInfo, imgUri: Uri?, preImgPath: String?) {
+    /* 기본적인 아이템 삽입 이벤트를 위한 함수 */
+    fun insertItem(item: RestaurantInfo) {
         viewModelScope.launch(Dispatchers.IO) {
             insideProgressing.postValue(true)
-            itemRepository.itemInsert(item, imgUri, preImgPath)
+            itemRepository.itemInsert(item)
+            insideProgressing.postValue(false)
+            insideWorkFinishFlag.postValue(true)
+        }
+    }
+
+    /* 기본적인 아이템 갱신 이벤트를 위한 함수 */
+    fun updateItem(item: RestaurantInfo, imgUri: Uri?, preImgPath: String?) {
+        viewModelScope.launch(Dispatchers.IO) {
+            insideProgressing.postValue(true)
+            itemRepository.itemUpdate(item, imgUri, preImgPath)
             insideProgressing.postValue(false)
             insideWorkFinishFlag.postValue(true)
         }

--- a/app/src/main/res/layout/activity_add.xml
+++ b/app/src/main/res/layout/activity_add.xml
@@ -13,6 +13,10 @@
             type="com.fallTurtle.myrestaurantgallery.model.room.RestaurantInfo" />
 
         <variable
+            name="date"
+            type="String" />
+
+        <variable
             name="spinnerEntries"
             type="String[]" />
     </data>
@@ -62,7 +66,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="4"
                     android:padding="4dp"
-                    android:text="@{info.date}"
+                    android:text="@{date}"
                     android:textSize="15sp"
                     android:gravity="center"
                     android:textColor="#000000"

--- a/app/src/main/res/layout/activity_add.xml
+++ b/app/src/main/res/layout/activity_add.xml
@@ -64,7 +64,6 @@
                     android:padding="4dp"
                     android:text="@{info.date}"
                     android:textSize="15sp"
-                    android:textAlignment="center"
                     android:gravity="center"
                     android:textColor="#000000"
                     android:autoSizeTextType="uniform"/>


### PR DESCRIPTION
1. 기존 Room은 insert에 충돌 시 replace하도록 규칙을 적용하고 update와 insert를 모두 insert 함수를 통해 하도록 조치함. 하지만 이러한 방식은 update 시마다 기존 것을 제거하고 새로운 걸 추가하는 형식, 따라서 추후 cascade delete 같은 복잡한 내용이 추가되면 오류가 생길 것이라 판단 -> update, insert를 분리하고 insert의 충돌 규칙을 제거
2. addActivity에서 각 뷰의 리스너를 통해 변경 내용을 binding된 info 객체에 적용하도록 해서 update 시 boilerplate 코드를 작성해야 하는 일을 예방함.
3. 2번 과정에서 발생한 update 시 이미지를 처리하지 않는 오류를 해결. 

* 위 과정에서 아이템 뷰모델과 리포지토리에도 update를 담당하는 메소드를 추가함.